### PR TITLE
Add support for analyze and genmove_analyze [Draft].

### DIFF
--- a/board/coordinate.py
+++ b/board/coordinate.py
@@ -62,7 +62,7 @@ class Coordinate:
 
         return GTP_X_COORDINATE[x_coord] + str(y_coord)
 
-    def convert_to_lz_format(self, pos: int) -> str:
+    def convert_to_analyze_format(self, pos: int) -> str:
         if pos == PASS:
             return "pass"
 

--- a/board/coordinate.py
+++ b/board/coordinate.py
@@ -52,18 +52,6 @@ class Coordinate:
             str: Go Text Protocol形式の座標。
         """
         if pos == PASS:
-            return "PASS"
-
-        if pos == RESIGN:
-            return "RESIGN"
-
-        x_coord = pos % self.board_size_with_ob - OB_SIZE + 1
-        y_coord = self.board_size - (pos // self.board_size_with_ob - OB_SIZE)
-
-        return GTP_X_COORDINATE[x_coord] + str(y_coord)
-
-    def convert_to_analyze_format(self, pos: int) -> str:
-        if pos == PASS:
             return "pass"
 
         if pos == RESIGN:

--- a/board/coordinate.py
+++ b/board/coordinate.py
@@ -62,6 +62,18 @@ class Coordinate:
 
         return GTP_X_COORDINATE[x_coord] + str(y_coord)
 
+    def convert_to_lz_format(self, pos: int) -> str:
+        if pos == PASS:
+            return "pass"
+
+        if pos == RESIGN:
+            return "resign"
+
+        x_coord = pos % self.board_size_with_ob - OB_SIZE + 1
+        y_coord = self.board_size - (pos // self.board_size_with_ob - OB_SIZE)
+
+        return GTP_X_COORDINATE[x_coord] + str(y_coord)
+
     def convert_to_sgf_format(self, pos: int) -> str:
         """プログラム内部の座標からSGF形式の座標に変換する。
 

--- a/gtp/client.py
+++ b/gtp/client.py
@@ -62,7 +62,9 @@ class GtpClient: # pylint: disable=R0902,R0903
             "komi",
             "showboard",
             "load_sgf",
-            "gogui-analyze_commands"
+            "gogui-analyze_commands",
+            "lz-analyze",
+            "lz-genmove_analyze"
         ]
         self.superko = superko
         self.board = GoBoard(board_size=board_size, komi=komi, check_superko=superko)
@@ -287,6 +289,75 @@ class GtpClient: # pylint: disable=R0902,R0903
 
         respond_success("")
 
+    def _lz_analyze(self, arg_list: List[str]) -> NoReturn:
+        color = arg_list[0]
+        interval = 0
+        if len(arg_list) >= 2:
+            interval = int(arg_list[1])/100
+
+        if color.lower()[0] == 'b':
+            to_move = Stone.BLACK
+        elif color.lower()[0] == 'w':
+            to_move = Stone.WHITE
+        else:
+            respond_failure("lz-analyze color")
+            return
+
+        analysis_query = {
+            "mode" : "lz",
+            "interval" : interval,
+            "ponder" : True
+        }
+        self.mcts.ponder(self.board, to_move, analysis_query)
+
+    def _lz_genmove_analyze(self, arg_list: List[str]) -> int:
+        color = arg_list[0]
+        interval = 0
+        if len(arg_list) >= 2:
+            interval = int(arg_list[1])/100
+
+        if color.lower()[0] == 'b':
+            genmove_color = Stone.BLACK
+        elif color.lower()[0] == 'w':
+            genmove_color = Stone.WHITE
+        else:
+            respond_failure("genmove color")
+            return
+
+        if self.use_network:
+            if self.policy_move:
+                # Policy Networkから着手生成
+                pos = generate_move_from_policy(self.network, self.board, genmove_color)
+                _, previous_move, _ = self.board.record.get(self.board.moves - 1)
+                if self.board.moves > 1 and previous_move == PASS:
+                    pos = PASS
+            else:
+                # モンテカルロ木探索で着手生成
+                if self.use_sequential_halving:
+                    pos = self.mcts.generate_move_with_sequential_halving(self.board, \
+                        genmove_color, self.time_manager, False)
+                else:
+                    analysis_query = {
+                        "mode" : "lz",
+                        "interval" : interval,
+                        "ponder" : False
+                    }
+                    pos = self.mcts.search_best_move(self.board, genmove_color, \
+                        self.time_manager, analysis_query)
+        else:
+            # ランダムに着手生成
+            legal_pos = [pos for pos in self.board.onboard_pos \
+                if self.board.is_legal_not_eye(pos, genmove_color)]
+            if legal_pos:
+                pos = random.choice(legal_pos)
+            else:
+                pos = PASS
+
+        if pos != RESIGN:
+            self.board.put_stone(pos, genmove_color)
+        return pos
+
+
     def run(self) -> NoReturn: # pylint: disable=R0912,R0915
         """Go Text Protocolのクライアントの実行処理。
         入力されたコマンドに対応する処理を実行し、応答メッセージを表示する。
@@ -366,9 +437,16 @@ class GtpClient: # pylint: disable=R0902,R0903
                 self.board.display_self_atari(Stone.BLACK)
                 self.board.display_self_atari(Stone.WHITE)
                 respond_success("")
+            elif input_gtp_command == "lz-analyze":
+                print("= ")
+                self._lz_analyze(command_list[1:])
+                print("")
+            elif input_gtp_command == "lz-genmove_analyze":
+                print("= ")
+                pos = self._lz_genmove_analyze(command_list[1:])
+                print("play {}\n".format(self.coordinate.convert_to_gtp_format(pos)))
             else:
                 respond_failure("unknown_command")
-
 
 def respond_success(response: str) -> NoReturn:
     """コマンド処理成功時の応答メッセージを表示する。

--- a/mcts/tree.py
+++ b/mcts/tree.py
@@ -135,15 +135,20 @@ class MCTSTree:
                 root = self.node[self.current_root]
 
                 if interval > 0 and \
-                       p == threshold-1 or elapsed > interval:
+                       (p == threshold-1 or elapsed > interval):
                     analysis_clock = time.time()
-                    sys.stdout.write(root.to_lz_analysis(board))
+                    mode = analysis_query.get("mode", "lz")
+                    sys.stdout.write(root.to_analysis(board, mode))
                     sys.stdout.flush()
 
                 if analysis_query.get("ponder", False):
                     rlist, _, _ = select.select([sys.stdin], [], [], 0)
                     if rlist:
                         break
+        if interval == 0:
+            mode = analysis_query.get("mode", "lz")
+            sys.stdout.write(root.to_analysis(board, mode))
+            sys.stdout.flush()
 
 
     def search_mcts(self, board: GoBoard, color: Stone, current_index: int, \

--- a/mcts/tree.py
+++ b/mcts/tree.py
@@ -81,7 +81,7 @@ class MCTSTree:
         next_index = root.get_best_move_index()
 
         # 探索結果と探索にかかった時間を表示する
-        pv_list = self.get_pv_lists(board.coordinate)
+        pv_list = self.get_pv_lists(self.get_root(), board.coordinate)
         root.print_search_result(board, pv_list)
         search_time = time_manager.calculate_consumption_time()
         po_per_sec = root.node_visits / search_time
@@ -146,7 +146,7 @@ class MCTSTree:
                        (p == threshold-1 or elapsed > interval):
                     analysis_clock = time.time()
                     mode = analysis_query.get("mode", "lz")
-                    sys.stdout.write(root.to_analysis(board, mode))
+                    sys.stdout.write(root.get_analysis(board, mode, self.get_pv_lists))
                     sys.stdout.flush()
 
                 if analysis_query.get("ponder", False):
@@ -155,7 +155,7 @@ class MCTSTree:
                         break
         if len(analysis_query) > 0 and interval == 0:
             mode = analysis_query.get("mode", "lz")
-            sys.stdout.write(root.to_analysis(board, mode))
+            sys.stdout.write(root.get_analysis(board, mode, self.get_pv_lists))
             sys.stdout.flush()
 
 
@@ -388,7 +388,7 @@ class MCTSTree:
         """
         return self.node[self.current_root]
 
-    def get_pv_lists(self, coord: Coordinate) -> Dict[str, List[str]]:
+    def get_pv_lists(self, root, coord: Coordinate) -> Dict[str, List[str]]:
         """探索した手の最善応手系列を取得する。
 
         Args:
@@ -397,8 +397,6 @@ class MCTSTree:
         Returns:
             Dict[str, List[str]]: 各手の最善応手系列を記録した辞書。
         """
-        root = self.get_root()
-
         pv_dict = {}
 
         for i in range(root.num_children):
@@ -406,7 +404,6 @@ class MCTSTree:
                 pv_list = self.get_best_move_sequence([root.action[i]], i)
                 pv_dict[coord.convert_to_gtp_format(root.action[i])] = \
                     [coord.convert_to_gtp_format(pv) for pv in pv_list]
-
 
         return pv_dict
 


### PR DESCRIPTION
Add support for ```lz-analyze``` and ```lz-genmove_analyze```.  Will add support for ```cgos-analyze``` and ```cgos-genmove_analyze``` in order to support for #50 .

## DONE
* Add support for ```lz-analyze``` and ```lz-genmove_analyze```.
* Add support for  ```cgos-analyze``` and ```cgos-genmove_analyze```.
* Work well on the Sabaki.
* Test on CGOS.
* Add support for PV.

## TODO
* Fix the code style.
