### PR TITLE
Improve #94 (plot_tree)

### DIFF
--- a/board/go_board.py
+++ b/board/go_board.py
@@ -411,6 +411,11 @@ class GoBoard: # pylint: disable=R0902
     def display(self, sym: int=0) -> NoReturn:
         """盤面を表示する。
         """
+        print_err(self.get_board_string(sym=sym))
+
+    def get_board_string(self, sym: int=0) -> str:
+        """盤面を表わす文字列を返す。
+        """
         board_string = f"Move : {self.moves}\n"
         board_string += f"Prisoner(Black) : {self.prisoner[0]}\n"
         board_string += f"Prisoner(White) : {self.prisoner[1]}\n"
@@ -432,7 +437,7 @@ class GoBoard: # pylint: disable=R0902
 
         board_string += "  +" + "-" * (self.board_size * 2 + 1) + "+\n"
 
-        print_err(board_string)
+        return board_string
 
 
     def display_self_atari(self, color: Stone) -> NoReturn:
@@ -545,6 +550,13 @@ class GoBoard: # pylint: disable=R0902
             List[int]: 置き石の座標のリスト。
         """
         return self.record.handicap_pos[:]
+
+    def set_history(self, move_history, handicap_history):
+        self.clear()
+        for handicap in handicap_history:
+            self.board.put_handicap_stone(handicap, Stone.BLACK)
+        for (color, pos, _) in move_history:
+            self.put_stone(pos, color)
 
     def count_score(self) -> int: # pylint: disable=R0912
         """領地を簡易的にカウントする。

--- a/board/pattern.py
+++ b/board/pattern.py
@@ -18,6 +18,17 @@ pattern_mask = np.array([
     [0xfffc, 0x00000001, 0x00000002],
 ], dtype=np.uint32)
 
+nb4_empty = [0] * 65536
+for i, _ in enumerate(nb4_empty):
+    if ((i >> 2) & 0x3) == 0:
+        nb4_empty[i] += 1
+    if ((i >> 6) & 0x3) == 0:
+        nb4_empty[i] += 1
+    if ((i >> 8) & 0x3) == 0:
+        nb4_empty[i] += 1
+    if ((i >> 12) & 0x3) == 0:
+        nb4_empty[i] += 1
+
 
 class Pattern:
     """配石パターンクラス。
@@ -37,17 +48,6 @@ class Pattern:
             -board_size_with_ob - 1, -board_size_with_ob, -board_size_with_ob + 1,
             -1, 1, board_size_with_ob - 1, board_size_with_ob, board_size_with_ob + 1
         ]
-
-        self.nb4_empty = [0] * 65536
-        for i, _ in enumerate(self.nb4_empty):
-            if ((i >> 2) & 0x3) == 0:
-                self.nb4_empty[i] += 1
-            if ((i >> 6) & 0x3) == 0:
-                self.nb4_empty[i] += 1
-            if ((i >> 8) & 0x3) == 0:
-                self.nb4_empty[i] += 1
-            if ((i >> 12) & 0x3) == 0:
-                self.nb4_empty[i] += 1
 
         # 眼のパターン
         eye_pat3 = [
@@ -148,7 +148,7 @@ class Pattern:
         Returns:
             int: 上下左右の空点数（最大4）
         """
-        return self.nb4_empty[self.pat3[pos]]
+        return nb4_empty[self.pat3[pos]]
 
     def get_eye_color(self, pos: int) -> Stone:
         """指定した座標の眼の色を取得する。

--- a/graph/plot_tree.py
+++ b/graph/plot_tree.py
@@ -99,8 +99,12 @@ def plot_tree_main(input_json_path: str, output_image_path: str, around_pv: bool
         )
 
         # エッジの作成
+        freshness = (item['index'] + 1) / len(node)
+        whiteness = 0.9
+        c = f"{int(freshness * whiteness * 255):02x}"
+        color = f"#{c}{c}{c}"
         penwidth = max(0.5, item['policy'] * 10)
-        dot.edge(str(parent_index), str(index), penwidth=f"{penwidth}")
+        dot.edge(str(parent_index), str(index), color=color, penwidth=f"{penwidth}")
 
     dot.render(output_image_path, format='png', view=False, cleanup=True)
 

--- a/gtp/client.py
+++ b/gtp/client.py
@@ -179,13 +179,7 @@ class GtpClient: # pylint: disable=R0902,R0903
 
         handicap_history = self.board.get_handicap_history()
 
-        self.board.clear()
-
-        for handicap in handicap_history:
-            self.board.put_handicap_stone(handicap, Stone.BLACK)
-
-        for (color, pos, _) in history[:-1]:
-            self.board.put_stone(pos, color)
+        self.board.set_history(history[:-1], handicap_history)
 
         respond_success("")
 

--- a/mcts/dump.py
+++ b/mcts/dump.py
@@ -1,8 +1,8 @@
 import json
-from typing import Any, Dict, NoReturn
+from typing import Any, Tuple, List, Dict, NoReturn
 
 from program import PROGRAM_NAME, VERSION, PROTOCOL_VERSION
-from board.go_board import GoBoard
+from board.go_board import GoBoard, copy_board
 from board.coordinate import Coordinate
 from board.stone import Stone
 from mcts.constant import NOT_EXPANDED
@@ -19,10 +19,12 @@ def dump_mcts_to_json(tree_dict: Dict[str, Any], board: GoBoard, superko: bool) 
         str: MCTSの状態を表すJSON文字列。
     """
     state = {
-        "dump_version": 1,
+        "dump_version": 2,
         "tree": tree_dict,
         "board_size": board.get_board_size(),
         "komi": board.get_komi(),
+        "move_history": _serializable_move_history(board.get_move_history()),
+        "handicap_history": board.get_handicap_history(),
         "superko": superko,
         "name": PROGRAM_NAME,
         "version": VERSION,
@@ -36,7 +38,12 @@ def enrich_mcts_dict(state: Dict[str, Any]) -> NoReturn:
     Args:
         state (Dict[str, Any]): MCTSの状態を表す辞書。
     """
-    coord = Coordinate(board_size=state["board_size"])
+    root_board = GoBoard(board_size=state["board_size"], komi=state["komi"], \
+                         check_superko=state["superko"])
+    root_board.set_history(_recovered_move_history(state["move_history"]), \
+                           state["handicap_history"])
+
+    coord = Coordinate(board_size=root_board.get_board_size())
     tree = state["tree"]
     node = tree["node"]
 
@@ -73,24 +80,31 @@ def enrich_mcts_dict(state: Dict[str, Any]) -> NoReturn:
         nodes_pool += expanded_children
 
     # その他いろいろな便利項目を追加
+    initial_move_color = _str_to_stone(tree["to_move"])
     for item in node:
         is_root = "parent_index" not in item
         if is_root:
             item["level"] = 0
             item["orders_along_path"] = []
+            item["gtp_moves_along_path"] = []
             item["to_move"] = tree["to_move"]
+            item["board_string"] = root_board.get_board_string()
             continue
         parent = node[item["parent_index"]]
+        index_in_brother = item["index_in_brother"]
+        gtp_move = coord.convert_to_gtp_format(parent["action"][index_in_brother])
         item["level"] = parent["level"] + 1
         item["orders_along_path"] = [*parent["orders_along_path"], item["order"]]
         item["to_move"] = _opposite_color(parent["to_move"])
+        item["gtp_moves_along_path"] = [*parent["gtp_moves_along_path"], gtp_move]
+        item["board_string"] = _get_updated_board_string(root_board, initial_move_color, \
+                                                         item["gtp_moves_along_path"])
         # ルートノードは以下の項目を持たないことに注意
-        index_in_brother = item["index_in_brother"]
         item["policy"] = parent["children_policy"][index_in_brother]
         item["visits"] = parent["children_visits"][index_in_brother]
         item["value"] = parent["children_value"][index_in_brother]
         item["value_sum"] = parent["children_value_sum"][index_in_brother]
-        item["gtp_move"] = coord.convert_to_gtp_format(parent["action"][index_in_brother])
+        item["gtp_move"] = gtp_move
         item["mean_value"] = item["value_sum"] / item["visits"]
         last_move_color = _opposite_color(item["to_move"])
         item["raw_black_winrate"] = _black_winrate(item["value"], last_move_color)
@@ -101,3 +115,54 @@ def _opposite_color(color):
 
 def _black_winrate(value, last_move_color):
     return value if last_move_color == "black" else 1.0 - value
+
+def _serializable_move_history(move_history: List[Tuple[Stone, int, Any]]) -> List[Tuple[str, int]]:
+    """着手の履歴をシリアライズ可能な値に変換する。ただしハッシュ値は廃棄する。
+
+    Args:
+        move_history (List[Tuple[Stone, int, np.array]]): 着手の履歴。
+
+    Returns:
+        Lizt[Tuple[str, int]]: シリアライズ可能なよう変換された着手履歴。
+    """
+    return [(_stone_to_str(color), pos) for (color, pos, _) in move_history]
+
+def _recovered_move_history(converted_move_history: List[Tuple[str, int]]) -> List[Tuple[Stone, int, Any]]:
+    """_serializable_move_historyで変換された着手履歴から元の着手履歴を復元する。
+ただしハッシュ値はNoneに置きかえられる。
+
+    Args:
+        converted_move_history (Lizt[Tuple[str, int]]): 変換された着手履歴。
+
+    Returns:
+        List[Tuple[Stone, int, Any]]: 復元された着手履歴。
+    """
+    return [(_str_to_stone(color_str), pos, None) for (color_str, pos) in converted_move_history]
+
+def _stone_to_str(color: Stone) -> str:
+    return 'black' if color == Stone.BLACK else 'white'
+
+def _str_to_stone(color_str: str) -> str:
+    return Stone.BLACK if color_str == 'black' else Stone.WHITE
+
+def _get_updated_board_string(root_board: GoBoard, initial_move_color: Stone, gtp_moves_along_path: List[str]) -> str:
+    """一連の着手後の盤面を表わす文字列を返す。
+
+    Args:
+        root_board (GoBoard): 着手前の盤面。
+        initial_move_color (Stone): 最初の着手の色。
+        gtp_moves_along_path (List[str]): 着手位置のリスト。
+
+    Returns:
+        str: 着手後の盤面を表わす文字列。
+    """
+    coord = Coordinate(board_size=root_board.get_board_size())
+    move_color = initial_move_color
+    # 「board = copy.deepcopy(root_board)」は遅いので避ける。
+    board = GoBoard(board_size=root_board.get_board_size(), komi=root_board.get_komi(), check_superko=root_board.check_superko)
+    copy_board(dst=board, src=root_board)
+    for (k, move) in enumerate(gtp_moves_along_path):
+        pos = coord.convert_from_gtp_format(move)
+        board.put_stone(pos, move_color)
+        move_color = Stone.get_opponent_color(move_color)
+    return board.get_board_string()


### PR DESCRIPTION
MCTSツリーの描画機能 (#94) への追加です.

![tree_graph](https://github.com/kobanium/TamaGo/assets/38910552/d10e3bab-d68d-4cd8-bc7a-ed8f0e32db9b)
(画像を右クリック → 新しいタブで画像を開く → マウスをノードにかざすと盤面を表示)

* 最近に展開された箇所ほどエッジの色を薄く
* マウスホバーで盤面を表示 (Chrome や Firefox で画像を開いた場合)

後者は「graphviz のノード ID を碁盤のアスキーアートにする」という無理矢理な手なのですが, 便利ではあります. 9路ならオーバヘッドは許容範囲ではないでしょうか. 念のため, 碁盤が大きい場合はオフになるようにしています. この機能のために下記を変更しました.

* 画像形式を PNG から SVG に
* `move_history` と `handicap_history` をダンプに追加
* ダンプ読み込み後の加工で `gtp_moves_along_path` と `board_string` を追加
* ヘルプ内の実行例で, `lz-genmove_analyze` のあと探索時の盤面に戻すため `undo` を追加
* (`nb4_empty`を外に出して, `GoBoard()`を何度も呼びだすケースを高速化)