### PR TITLE
numpy 2.5でMCTS探索中にプロセスが異常終了する問題を修正

### DIFF
--- a/board/record.py
+++ b/board/record.py
@@ -39,7 +39,9 @@ class Record:
         if moves < MAX_RECORDS:
             self.color[moves] = color
             self.pos[moves] = pos
-            self.hash_value[moves] = hash_value
+            # hash_valueは長さ1の配列なので中身のスカラーを取り出す
+            # (numpy 2.5以降は配列からスカラー枠への代入がValueErrorになる)
+            self.hash_value[moves] = hash_value[0]
         else:
             print_err("Cannot save move record.")
 


### PR DESCRIPTION
## 問題
numpy 2.5 以降の環境で、着手を記録する際に `ValueError: setting an array element with a sequence.` が発生し、探索中にエンジンのプロセスが異常終了します(GTP経由で使っている場合は engine died に見えます)。

```
File "board/go_board.py", line 184, in put_stone
    self.record.save(self.moves, color, pos, self.positional_hash)
File "board/record.py", line 42, in save
    self.hash_value[moves] = hash_value
ValueError: setting an array element with a sequence.
```

## 原因
`GoBoard.positional_hash` は長さ1のnumpy配列(`np.zeros(1, dtype=np.uint64)`)ですが、`Record.save` がこれを `self.hash_value[moves]`(スカラー要素)へそのまま代入しています。この「長さ1配列→スカラー要素」の代入は numpy 2.0 までは非推奨警告つきで許容されていましたが、numpy 2.5 で ValueError に変更されました。`requirements.txt` の指定が `numpy>=1.19.5` のため、新しい環境では numpy 2.5 が入りこの問題が顕在化します。

## 修正
配列から中身のスカラー(`hash_value[0]`)を取り出して代入するようにしました。どのnumpyバージョンでも正しく動作します。

## 検証
- numpy 2.5.0 (Python 3.12): 修正前は2手目の `put_stone` で ValueError → 修正後は正常動作
- numpy 2.0.2: 回帰なし
- スーパーコウ判定(ハッシュ履歴の照合)を含む対局で動作確認済み