### PR TITLE
解析出力が未反映のミニバッチを含まず、探索回数がバッチサイズ未満のときゼロ除算で異常終了する問題を修正

### DIFF
--- a/mcts/node.py
+++ b/mcts/node.py
@@ -472,8 +472,11 @@ class MCTSNode: # pylint: disable=R0902, R0904
         """
         out = ""
         if mode == "cgos":
+            # 探索結果が未反映 (node_visits == 0) の場合はゼロ除算を避け、
+            # ニューラルネットワークの評価値で代用する
             cgos_dict = {
-                "winrate" : float(self.node_value_sum) / self.node_visits,
+                "winrate" : float(self.node_value_sum) / self.node_visits \
+                    if self.node_visits > 0 else float(self.raw_value),
                 "visits" : self.node_visits,
                 "moves" : []
             }

--- a/mcts/tree.py
+++ b/mcts/tree.py
@@ -162,6 +162,10 @@ class MCTSTree(MCTSTreeBase): # pylint: disable=R0902
                         break
 
         if len(analysis_query) > 0 and interval == 0:
+            # 未反映のミニバッチ (最大 batch_size - 1 プレイアウト) を
+            # 反映してから解析結果を出力する
+            if len(self.batch_queue.node_index) > 0:
+                self.process_mini_batch(board)
             root = self.node[self.current_root]
             mode = analysis_query.get("mode", "lz")
             sys.stdout.write(root.get_analysis(board, mode, self.get_pv_lists))


### PR DESCRIPTION
## 問題

cgos-genmove_analyze / cgos-analyze の応答生成時に、探索結果が1つも反映されていないと ZeroDivisionError でエンジンが異常終了します (GTP 経由では engine died に見えます)。

```
$ printf "cgos-genmove_analyze b\nquit\n" | python main.py --model model/model.bin --const-time 1 --batch-size 64
...
  File "mcts/node.py", line 476, in get_analysis_from_status_list
    "winrate" : float(self.node_value_sum) / self.node_visits,
ZeroDivisionError: float division by zero
```

発生条件 (いずれも v0.11.1 で再現確認済み):

1. **`--const-time 1〜3` + `--batch-size 64`**: プロセス最初の1手で必ず発生します。探索速度の初期値が 20 visits/s のため初手の探索予算が 20〜60 となり、バッチサイズ 64 に届きません (2手目以降は実測速度に較正されるため初手のみ)
2. **持ち時間制 (`--time`) の時間切迫時**: 探索予算 = 実測速度 × 残り時間/10 のため、残り時間が 640/実測速度 秒 (実測 806 visits/s の環境で約0.8秒) を切ると発生します。時間切れ寸前の負けかけの局面ですが、時間切れ負けと違いエンジンごと落ちるため、連続対局の残りが全て失われます
3. `--visits` < バッチサイズ: 最小再現 (`--visits 4 --batch-size 8` など)

## 原因

探索ループはミニバッチが満杯になったときだけ process_mini_batch を呼ぶため、ループ終了時に最大 batch_size − 1 プレイアウトが未反映のままキューに残ります。search() の解析出力 (interval == 0) はこの反映より前に実行されるため:

- 探索回数がバッチサイズ未満だと node_visits が 0 のまま除算に到達して落ちます
- 落ちない場合でも、報告される winrate / visits に未反映分が含まれません (例: `--visits 100 --batch-size 8` で visits:96 と報告される)

## 修正

1. mcts/tree.py: interval == 0 の解析出力の直前に未反映のミニバッチを反映するようにしました (search_best_move 側の既存の反映処理は空キューに対する no-op になるだけで、処理回数は増えません)
2. mcts/node.py: node_visits == 0 のガードを追加し、ニューラルネットワークの評価値 (raw_value) で代用するようにしました (ストリーミング出力 interval > 0 の経路の防御)

## 検証 (v0.11.1、Python 3.13 / torch 2.10)

- 修正前: 上記1〜3の各構成で ZeroDivisionError → 修正後: 正常応答 (例: `--const-time 1 --batch-size 64` で `{"winrate":...,"visits":20,...}`)
- `--visits 100 --batch-size 8`: 報告 visits が 96 → 100 になり、全探索が反映されることを確認
- lz-genmove_analyze / 通常の genmove: 回帰なしを確認
- 動作確認には同一構造の未学習の重みを使用しました (現象はバッチ処理の構造に起因し、モデルの重みに依存しません)

🤖 Generated with [Claude Code](https://claude.com/claude-code)